### PR TITLE
fix typos

### DIFF
--- a/basic_operation.py
+++ b/basic_operation.py
@@ -270,11 +270,12 @@ current_num_of_procs = CurrentNumOfProcs()
 
 def reduced_form_with_sign(tpl):
     '''
-    Assuming the 2-by-2 matrix correspoding to tpl
+    Assuming the 2-by-2 matrix corresponding to tpl
     is positive definite, returns
     ((n, r, m), sgn)
     where (n, r, m) is unmimodular equivalent to tpl
     s.t. n <= m and 0 <= r <= n.
+
     sgn is the determinant of an element GL2(ZZ) that gives
     the unimodular equivalence.
     '''
@@ -377,7 +378,7 @@ def _dict_parallel(f, ls):
 def _mul_fourier(mp1, mp2, prec, cuspidal=False, hol=False):
     '''
     Returns the dictionary of the product of Fourier series
-    correspoding to mp1 and mp2.
+    corresponding to mp1 and mp2.
     '''
     tupls_s = _partition_mul_fourier(
         prec, cuspidal=cuspidal, hol=hol,

--- a/const.py
+++ b/const.py
@@ -506,7 +506,8 @@ class ConstDivision(ConstVectBase):
 
     '''Returns a construction for a vector valued modulular form by dividing
     a scalar valued modular form.
-    This construction correponds to
+
+    This construction corresponds to
     sum(F*a for F, a in zip(consts, coeffs)) / scalar_const.
     Needed prec is increased by inc.
     '''
@@ -722,7 +723,7 @@ class CalculatorVectValued(object):
 
     def rdeps(self, const):
         '''Returns a subset of the union of all_dependencies and
-        set(self._const_vecs) cosisting elements
+        set(self._const_vecs) consisting elements
         that depend on const with depth1.
         '''
         return {c for c in self.all_dependencies().union(set(self._const_vecs))

--- a/diff_operator_pullback_vector_valued.py
+++ b/diff_operator_pullback_vector_valued.py
@@ -168,7 +168,7 @@ class DiffZOperatorElement(object):
         return self._pol_idc_dct
 
     def diff(self, pol, r_ls):
-        '''pol is a polynomial in _Z_ring and R is a 2 by 2 marix.
+        '''pol is a polynomial in _Z_ring and R is a 2 by 2 matrix.
         Return (the derivative of pol * exp(2pi R^t Z)) / exp(R^t Z) as a polynomial.
         R = matrix(2, r_ls)
         '''
@@ -221,7 +221,7 @@ def D_tilde_nu(alpha, nu, pol, r_ls, **kwds):
     return pol
 
 
-# The repressentation space of Gl2 is homogenous polynomial of u1 and u2.
+# The representation space of Gl2 is homogeneous polynomial of u1 and u2.
 _U_ring = PolynomialRing(QQ, names='u1, u2')
 _Z_U_ring = PolynomialRing(QQ, names='u1, u2, z11, z12, z21, z22')
 

--- a/elements.py
+++ b/elements.py
@@ -868,7 +868,8 @@ class SymWtGenElt(object):
 
     '''
     Let Symm(j) be the symmetric tensor representation of degree j of GL2.
-    Symm(j) is the space of homogenous polynomials of u1 and u2 of degree j.
+
+    Symm(j) is the space of homogeneous polynomials of u1 and u2 of degree j.
     We take u1^j, .. u2^j as a basis of Symm(j)
     An instance of this class corresponds to
     a tuple of j Fourier expansions of degree 2.

--- a/hecke_module.py
+++ b/hecke_module.py
@@ -248,8 +248,9 @@ class HeckeModuleElement(object):
         '''
         Assuming self is a vector valued Siegel modular form, returns
         tpl th Fourier coefficient of T(p^i)self.
+
         Here tpl is an triple of integers or a tuple (t, a) with
-        t: triple of integers and a: intger.
+        t: triple of integers and a: integer.
         cf. Arakawa, vector valued Siegel's modular forms of degree two and
         the associated Andrianov L-functions, pp 166.
         '''

--- a/modular_form_module.py
+++ b/modular_form_module.py
@@ -44,7 +44,8 @@ class ModularFormModule(object):
     def eigenvector_with_eigenvalue(self, lin_op, lm):
         '''Let lin_op(f, t) be an endomorphsim of self and assume
         it has a unique eigenvector (up to constant) with eigenvalue lm.
-        This medhod returns an eigenvector.
+
+        This method returns an eigenvector.
         '''
         basis = self.basis()
         dim = len(basis)

--- a/rankin_cohen_diff.py
+++ b/rankin_cohen_diff.py
@@ -86,7 +86,7 @@ def _rankin_cohen_bracket_func(Q, rnames=None, unames=None):
     R(n-1) = [[r(n-1)0, r(n-1)],
               [r(n-1), r(n-1)2]]
     be the symmetric matrices.
-    Q is a homogenous polynomial of u1 and u2
+    Q is a homogeneous polynomial of u1 and u2
     whose coefficient is a polynomial of R0, ..., R(n-1).
     This function returns a Rakin-Cohen type differential
     operator corresponding to Q.
@@ -394,6 +394,7 @@ def _bracket_vec_val(vecs):
 def vector_valued_rankin_cohen(f, vec_val):
     '''
     Rankin-Cohen type differential operator defined by van Dorp.
+
     Let f be a scalar valued Siegel modular form of weight det^k
     and vec_val be a vector valued Siegel modular form of weight
     det^l Sym(j).

--- a/rankin_cohen_diff.py
+++ b/rankin_cohen_diff.py
@@ -88,7 +88,7 @@ def _rankin_cohen_bracket_func(Q, rnames=None, unames=None):
     be the symmetric matrices.
     Q is a homogeneous polynomial of u1 and u2
     whose coefficient is a polynomial of R0, ..., R(n-1).
-    This function returns a Rakin-Cohen type differential
+    This function returns a Rankin-Cohen type differential
     operator corresponding to Q.
     The operator is a function that takes a list of n forms.
     '''

--- a/standard_l_scalar_valued.py
+++ b/standard_l_scalar_valued.py
@@ -67,7 +67,8 @@ def algebraic_part_of_standard_l(f, l, space_of_cusp_form=None):
     f: cuspidal eigen form of degree 2 of weight k with k: even.
     l: positive even integer s.t. l <= k - 4
     space_of_cusp_form: space of cusp form that f belongs to.
-    If f.parent_space is not None, then this can be ommited.
+
+    If f.parent_space is not None, then this can be omitted.
     Return the algebriac part of the standard L of f at l
     (\tilde{\Lambda}(f, l, St)) defined in [Kat], pp 72.
     '''

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -73,7 +73,7 @@ class ConstsTest(unittest.TestCase):
         self.assertTrue(dependencies(c5), set([c1, c2, c3, c4]))
 
     def test_needed_precs(self):
-        '''Test the funciton needed_precs.
+        '''Test the function needed_precs.
         '''
         j = 10
         c1 = ConstVectValued(j, [SMFC([5, 5])], 0, None)

--- a/tests/test_pullback_se_vector_valued.py
+++ b/tests/test_pullback_se_vector_valued.py
@@ -112,7 +112,7 @@ class TestPullBackVectorValued(unittest.TestCase):
 
     @skip("Not ok")
     def test_14_identity(self):
-        '''Test idenitity (14) in [Bö].
+        '''Test identity (14) in [Bö].
         '''
         n = 2
         for _ in range(50):

--- a/vector_valued_impl/sym10/relation.py
+++ b/vector_valued_impl/sym10/relation.py
@@ -8,9 +8,10 @@ from degree2.vector_valued_smfs import vector_valued_siegel_modular_forms as vvs
 
 
 def relation(wt, data_directory=None):
-    '''For a given weight wt, this funciton returns a dict whose set of keys
+    '''For a given weight wt, this function returns a dict whose set of keys
     is equal to a set of instances of ConstMul with weight wt.
-    Its value is a rational number. This dictionary represents a releation
+
+    Its value is a rational number. This dictionary represents a relation
     among keys.
     '''
     wts = (24, 26, 27, 29)

--- a/vector_valued_impl/sym10/tests/test_division.py
+++ b/vector_valued_impl/sym10/tests/test_division.py
@@ -148,7 +148,8 @@ def _anihilate_pol(k, M):
     for generators of M_{det^* sym(10)} and an instance of
     ConstDivision.
     M: an instance of Sym10EvenDiv or Sym10OddDiv.
-    Return a polynomial pl such that the subspace of M anihilated by pl(T(2))
+
+    Return a polynomial pl such that the subspace of M annihilated by pl(T(2))
     is equal to the subspace of holomorphic modular forms.
     '''
     R = PolynomialRing(QQ, names="x")

--- a/vector_valued_smfs.py
+++ b/vector_valued_smfs.py
@@ -150,10 +150,11 @@ class GivenWtBase(VectorValuedSiegelModularForms):
         pass
 
     def _basis_const_base(self, ignored_dct):
-        '''This method is used for implmentation of _basis_const.
+        '''This method is used for implementation of _basis_const.
         ignored_dct is a dictionary whose key is an element of self._gen_consts
         and its value is a sub lift of [4, 6, 10, 12].
-        For exmaple if ignored_dct = {c: [4]} and F is a vector valued modular
+
+        For example if ignored_dct = {c: [4]} and F is a vector valued modular
         form that corresponds to c, then
         we do not use F * (a monomial including es4) when constructing a basis.
         '''


### PR DESCRIPTION
as found using `codespell`